### PR TITLE
First blog post added: Kubefed archiving

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,3 +60,5 @@ nav:
     - FAQ: contributing/faq.md
   - Blog:
     - Index: blog/index.md
+    - 2022:
+      - Archiving Kubefed on Jan 3rd, 2023: blog/2022/2022-11-16_archiving-kubefed-on-Jan-3-2023.md

--- a/site-src/blog/2022/2022-11-16_archiving-kubefed-on-Jan-3-2023.md
+++ b/site-src/blog/2022/2022-11-16_archiving-kubefed-on-Jan-3-2023.md
@@ -1,0 +1,28 @@
+---
+title: "Archiving Kubefed on Jan 3, 2023"
+date: 2022-11-16
+---
+
+<small style="position:relative; top:-10px;">
+  :octicons-calendar-24: November 16, 2022 ·
+  :octicons-clock-24: 5 min read
+</small>
+
+As discussed over the past few SIG meetings, Kubecon, and this list, [KubeFed][kubefed-repo] is heading for archival.
+We plan to create the tombstone commit and complete the process in seven weeks on Jan 3, 2023 so that there's time to get any last changes into the main repo.
+This is meant to clarify the state of the ‘federation’ concept and associated projects in Kubernetes and to better set expectations around development and support in the area. Archiving will enable us to send a clear signal about the direction the SIG is headed in and how we will approach our work.
+
+**Archival is not deletion** and the code will remain on [GitHub][kubefed-repo] for reference or to fork and start your own projects. Nothing is going away and those who rely on kubefed can base new projects on the source, expanding and collaborating as you see fit.
+
+We want to thank everyone who has contributed to [Kubefed][kubefed-repo] over the past few years, it's been a huge effort from many people and has brought a ton of value to the community. We recognize and appreciate all of your hard work.
+
+While we don't have a SIG-endorsed replacement project and will not be linking to other projects from the tombstone, we will be linking to this thread. We welcome the community to chime in here with alternatives you're using or your own projects in the space.
+
+Thanks all!
+
+Jeremy Olmsted-Thompson
+Paul Morie
+
+SIG Multicluster Chairs
+
+[kubefed-repo]:https://github.com/kubernetes-sigs/kubefed

--- a/site-src/blog/index.md
+++ b/site-src/blog/index.md
@@ -1,1 +1,18 @@
 # Blog
+
+## [Archiving Kubefed on January 3rd, 2023][Archiving Kubefed]
+
+<small style="position:relative; top:-10px;">
+  :octicons-calendar-24: November 16, 2022 ·
+  :octicons-clock-24: 5 min read
+</small>
+
+As discussed over the past few SIG meetings, Kubecon, and this list, [KubeFed][kubefed-repo] is heading for archival.
+
+We plan to create the tombstone commit and complete the process in seven weeks on Jan 3, 2023 so that there's time to get any last changes into the main repo.
+
+This is meant to clarify the state of the ‘federation’ concept and associated projects in Kubernetes and to better set expectations around development and support in the area. Archiving will enable us to send a clear signal about the direction the SIG is headed in and how we will approach our work.
+[:octicons-arrow-right-24: Continue reading][Archiving Kubefed]
+
+[Archiving Kubefed]:/blog/2022/2022-11-16_archiving-kubefed-on-Jan-3-2023/
+[kubefed-repo]:https://github.com/kubernetes-sigs/kubefed


### PR DESCRIPTION
Added first blog post as "Kubefed archive post".
Although mkdocs now has a [ "blog feature"](https://squidfunk.github.io/mkdocs-material/blog/2022/09/12/blog-support-just-landed/), it is subject to an insider sponsorship.
I have therefore replicated here the blog structure of the Gateway API web site, which means duplicating some of the post material in blog/index.md.