### PR TITLE
More cleanup of extra pges

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,11 +42,6 @@ nav:
   - Guides:
     - Index: guides/index.md
     - Implementation Guidelines: guides/guidelines.md
-    - Implementations:
-        GKE Multicluster Services: guides/gke-mcs.md
-        Submariner: guides/submariner-mcs.md
-        Istio: guides/istio.md
-        Gateway API: guides/gateway-api.md
   - Reference:
     - Namespace Sameness: concepts/namespace-sameness.md
     - ClusterSet: api-types/cluster-set.md
@@ -56,7 +51,7 @@ nav:
   - Contributing:
     - How to Get Involved: contributing/index.md
     - FAQ: contributing/faq.md
-  - Blog:
+  - Announcements:
     - Index: blog/index.md
     - 2022:
       - Archiving Kubefed on Jan 3rd, 2023: blog/2022/2022-11-16_archiving-kubefed-on-Jan-3-2023.md

--- a/site-src/blog/index.md
+++ b/site-src/blog/index.md
@@ -1,4 +1,4 @@
-# Blog
+# Announcements 
 
 ## [Archiving Kubefed on January 3rd, 2023][Archiving Kubefed]
 


### PR DESCRIPTION
Renamed blog->announcements, remove blank implementations pages.